### PR TITLE
feat(UrlAction): add ability to use an authorization token

### DIFF
--- a/src/config/job-config/actions/urlaction/urlaction.interface.ts
+++ b/src/config/job-config/actions/urlaction/urlaction.interface.ts
@@ -5,6 +5,7 @@ export interface URLJobActionOptions {
   url: string;
   method?: "GET" | "POST" | "PUT" | "DELETE";
   headers?: Record<string, string>;
+  authTokenEnvVar?: "";
   body?: unknown;
 }
 

--- a/src/config/job-config/actions/urlaction/urlaction.interface.ts
+++ b/src/config/job-config/actions/urlaction/urlaction.interface.ts
@@ -5,7 +5,7 @@ export interface URLJobActionOptions {
   url: string;
   method?: "GET" | "POST" | "PUT" | "DELETE";
   headers?: Record<string, string>;
-  authTokenEnvVar?: "";
+  authTokenEnvVar?: string;
   body?: unknown;
 }
 

--- a/src/config/job-config/actions/urlaction/urlaction.service.ts
+++ b/src/config/job-config/actions/urlaction/urlaction.service.ts
@@ -6,15 +6,20 @@ import {
 } from "../../jobconfig.interface";
 import { URLJobAction } from "./urlaction";
 import { isURLJobActionOptions } from "./urlaction.interface";
+import { ConfigService } from "@nestjs/config";
 
 @Injectable()
 export class URLJobActionCreator implements JobActionCreator<JobDto> {
-  constructor() {}
+  private readonly configService: ConfigService;
+  constructor(configService: ConfigService) {
+    this.configService = configService;
+  }
 
   public create<Options extends JobActionOptions>(options: Options) {
     if (!isURLJobActionOptions(options)) {
       throw new Error("Invalid options for URLJobAction.");
     }
-    return new URLJobAction(options);
+    const token = this.configService.get<string>(options.authTokenEnvVar || "");
+    return new URLJobAction(options, token || "");
   }
 }

--- a/src/config/job-config/actions/urlaction/urlaction.spec.ts
+++ b/src/config/job-config/actions/urlaction/urlaction.spec.ts
@@ -8,11 +8,15 @@ describe("URLJobAction", () => {
     actionType: "url",
     url: "http://localhost:3000/api/v3/health?jobid={{id}}",
     method: "GET",
-    headers: { accept: "application/json" },
+    headers: {
+      accept: "application/json",
+      Authorization: "Bearer {{@authToken}}",
+    },
     body: "This is the body.",
   };
 
-  const action = new URLJobAction<CreateJobDto>(config);
+  const authorizationToken = "TheAuthToken";
+  const action = new URLJobAction<CreateJobDto>(config, authorizationToken);
 
   beforeEach(() => {
     global.fetch = jest.fn();
@@ -40,7 +44,10 @@ describe("URLJobAction", () => {
       "http://localhost:3000/api/v3/health?jobid=12345",
       {
         method: "GET",
-        headers: { accept: "application/json" },
+        headers: {
+          accept: "application/json",
+          Authorization: "Bearer TheAuthToken",
+        },
         body: "This is the body.",
       },
     );
@@ -62,7 +69,10 @@ describe("URLJobAction", () => {
       "http://localhost:3000/api/v3/health?jobid=12345",
       {
         method: "GET",
-        headers: { accept: "application/json" },
+        headers: {
+          accept: "application/json",
+          Authorization: "Bearer TheAuthToken",
+        },
         body: "This is the body.",
       },
     );


### PR DESCRIPTION
Proposal on how to add a token to URLAction:

- the url action specifies which env variable to get the token from and uses templating mechanism to use it its header
- the token needs to be added as env variable to the backend deployment


Example job config for a URLAction with token:

```
    {
      "jobType": "archive",
      "create": {
        "auth": "#all",
        "actions": [
          {
            "actionType": "log"
          },
          {
            "actionType": "url",
            "url": "https://scopem-openem.ethz.ch/archiver/api/v1/archiver/jobs",
            "method": "POST",
            "authTokenEnvVar": "ETHZ_ARCHIVER_BASIC_AUTH_TOKEN",
            "headers": {
              "accept": "application/json",
              "content-type": "application/json",
              "Authorization": "Basic {{@authToken}}"
            },
            "body": "{\"Type\": \"{{type}}\",\"Id\": \"{{id}}\"}"
          }
        ]
      },
```